### PR TITLE
Removing provisioner tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```hcl
 module "app-mesh" {
-    source = "github.com/pbs/terraform-aws-app-mesh-module?ref=0.0.1"
+    source = "github.com/pbs/terraform-aws-app-mesh-module?ref=x.y.z"
 }
 ```
 
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "app-mesh" {
-  source = "github.com/pbs/terraform-aws-app-mesh-module?ref=0.0.1"
+  source = "github.com/pbs/terraform-aws-app-mesh-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -38,7 +38,7 @@ module "app-mesh" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.0.1`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -72,7 +72,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_appmesh_mesh.mesh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appmesh_mesh) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,0 @@
-# Try to keep data aquired by this module here
-
-data "aws_caller_identity" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -11,7 +11,6 @@ locals {
       "${var.organization}:billing:product"     = var.product
       "${var.organization}:billing:environment" = var.environment
       creator                                   = local.creator
-      provisioner                               = data.aws_caller_identity.current.user_id
       repo                                      = var.repo
     }
   )


### PR DESCRIPTION
This tag doesn't help much, and causes issues with dependencies updating in weird orders.